### PR TITLE
R7000 dnsmasq args

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-	"domain": "netflix.com",
-	"dns-server-repo": "http://netflix.parrot-bytes.com/?oldips={oldIps}&domain={domain}",
+	"domain": "example.com",
+	"dns-server-repo": "http://example-dns-server-repo.com/?oldips={oldIps}&domain={domain}",
 	"used-profile": "generic",
 	"profiles": {
 		"uci": {
@@ -17,7 +17,7 @@
 				["killall","dnsmasq"],
 				["dnsmasq","-c", "1500", "--log-async", "-n"]
 			],
-			"dnsmasq-config-path": "/tmp/dnsmasq.conf"
+			"dnsmasq-config-path": "/tmp/etc/dnsmasq.conf"
 		}
 	}
 }

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
-	"domain": "example.com",
-	"dns-server-repo": "http://example-dns-server-repo.com/?oldips={oldIps}&domain={domain}",
+	"domain": "netflix.com",
+	"dns-server-repo": "http://netflix.parrot-bytes.com/?oldips={oldIps}&domain={domain}",
 	"used-profile": "generic",
 	"profiles": {
 		"uci": {
@@ -17,7 +17,7 @@
 				["killall","dnsmasq"],
 				["dnsmasq","-c", "1500", "--log-async", "-n"]
 			],
-			"dnsmasq-config-path": "/tmp/etc/dnsmasq.conf"
+			"dnsmasq-config-path": "/tmp/dnsmasq.conf"
 		}
 	}
 }

--- a/custom-dns-server.py
+++ b/custom-dns-server.py
@@ -65,6 +65,8 @@ def customdns(disabled, config):
 
 		# restart dnsmasqd
 		for cmd in profile["restart-dnsmasq"]:
+			if cmd[0] is "dnsmasq":
+				cmd.append("--conf-file=" + profile["dnsmasq-config-path"])
 			subprocess.call(cmd)
 
 customdns(os.path.exists(getrelpath("disabled")), getconfig(getrelpath("config.json")))

--- a/custom-dns-server.py
+++ b/custom-dns-server.py
@@ -62,9 +62,12 @@ def customdns(disabled, config):
 					with open(profile["dnsmasq-config-path"], "a") as myfile:
 						myfile.write("server=/%s/%s\n" % (config["domain"], ip))
 
-
+		
 		# restart dnsmasqd
 		for cmd in profile["restart-dnsmasq"]:
+			if cmd[0] is "dnsmasq":
+				cmd.append("--conf-file=" + profile["dnsmasq-config-path"])
 			subprocess.call(cmd)
+
 
 customdns(os.path.exists(getrelpath("disabled")), getconfig(getrelpath("config.json")))

--- a/custom-dns-server.py
+++ b/custom-dns-server.py
@@ -62,12 +62,9 @@ def customdns(disabled, config):
 					with open(profile["dnsmasq-config-path"], "a") as myfile:
 						myfile.write("server=/%s/%s\n" % (config["domain"], ip))
 
-		
+
 		# restart dnsmasqd
 		for cmd in profile["restart-dnsmasq"]:
-			if cmd[0] is "dnsmasq":
-				cmd.append("--conf-file=" + profile["dnsmasq-config-path"])
 			subprocess.call(cmd)
-
 
 customdns(os.path.exists(getrelpath("disabled")), getconfig(getrelpath("config.json")))


### PR DESCRIPTION
On my R7000 (DD-WRT) I have to use the --conf-file arguement when restarting dnsmasq. Maybe this should be used by default, as this option should work anywhere.
